### PR TITLE
Getter functions

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -1,123 +1,123 @@
 {
     "minerals": [
         {
-            "mineralId": 1,
+            "id": 1,
             "name": "Lunarium"
         },
         {
-            "mineralId": 2,
+            "id": 2,
             "name": "Stellarite"
         },
         {
-            "mineralId": 3,
+            "id": 3,
             "name": "Voidquartz"
         },
         {
-            "mineralId": 4,
+            "id": 4,
             "name": "Cosmonite"
         },
         {
-            "mineralId": 5,
+            "id": 5,
             "name": "Novacrystal"
         },
         {
-            "mineralId": 6,
+            "id": 6,
             "name": "Nebulium"
         },
         {
-            "mineralId": 7,
+            "id": 7,
             "name": "Gravitite"
         },
         {
-            "mineralId": 8,
+            "id": 8,
             "name": "Astralite"
         }
     ],
     "colonies": [
         {
-            "colonyId": 1,
+            "id": 1,
             "name": "Olympus Prime"
         },
         {
-            "colonyId": 2,
+            "id": 2,
             "name": "Proxima"
         },
         {
-            "colonyId": 3,
+            "id": 3,
             "name": "Mercurio"
         },
         {
-            "colonyId": 4,
+            "id": 4,
             "name": "Awkwa Four"
         },
         {
-            "colonyId": 5,
+            "id": 5,
             "name": "Plunaria"
         }
     ],
     "governors": [
         {
-            "governorId": 1,
+            "id": 1,
             "colonyId": 1,
             "name": "Bill Hader",
             "isActive": true
         },
         {
-            "governorId": 2,
+            "id": 2,
             "colonyId": 2,
             "name": "Will Hader",
             "isActive": false
         },
         {
-            "governorId": 3,
+            "id": 3,
             "colonyId": 2,
             "name": "Julia Louis Dreyfus",
             "isActive": true
         },
         {
-            "governorId": 4,
+            "id": 4,
             "colonyId": 1,
             "name": "Darth Tater",
             "isActive": true
         },
         {
-            "governorId": 5,
+            "id": 5,
             "colonyId": 3,
             "name": "Larry David",
             "isActive": false
         },
         {
-            "governorId": 6,
+            "id": 6,
             "colonyId": 3,
             "name": "George Washington",
             "isActive": true
         },
         {
-            "governorId": 7,
+            "id": 7,
             "colonyId": 3,
             "name": "Billy Bob Thornton",
             "isActive": false
         },
         {
-            "governorId": 8,
+            "id": 8,
             "colonyId": 4,
             "name": "Walter Goggins",
             "isActive": true
         },
         {
-            "governorId": 9,
+            "id": 9,
             "colonyId": 4,
             "name": "Ralph Fiennes",
             "isActive": true
         },
         {
-            "governorId": 10,
+            "id": 10,
             "colonyId": 5,
             "name": "Elmo",
             "isActive": true 
         },
         {
-            "governorId": 11,
+            "id": 11,
             "colonyId": 5,
             "name": "",
             "isActive": false
@@ -125,32 +125,32 @@
     ],
     "facilities": [
         {
-            "facilityId": 1,
+            "id": 1,
             "name": "Celestial Depot",
             "isActive": true
         },
         {
-            "facilityId": 2,
+            "id": 2,
             "name": "Galactic Mart",
             "isActive": false
         },
         {
-            "facilityId": 3,
+            "id": 3,
             "name": "Stardust Market",
             "isActive": true
         },
         {
-            "facilityId": 4,
+            "id": 4,
             "name": "Space Mini Mart",
             "isActive": true
         },
         {
-            "facilityId": 5,
+            "id": 5,
             "name": "Cosmic Warehouse",
             "isActive": false
         },
         {
-            "facilityId": 6,
+            "id": 6,
             "name": "Orbital Refinery",
             "isActive": true
         }
@@ -158,67 +158,67 @@
     ],
     "colonyMinerals": [
         {
-            "colonyMineralId": 1,
+            "id": 1,
             "colonyId": 1,
             "mineralId": 1,
             "quantity": 20
         },
         {
-            "colonyMineralId": 2,
+            "id": 2,
             "colonyId": 1,
             "mineralId": 7,
             "quantity": 20
         },
         {
-            "colonyMineralId": 3,
+            "id": 3,
             "colonyId": 2,
             "mineralId": 8,
             "quantity": 20
         },
         {
-            "colonyMineralId": 4,
+            "id": 4,
             "colonyId": 2,
             "mineralId": 6,
             "quantity": 20
         },
         {
-            "colonyMineralId": 5,
+            "id": 5,
             "colonyId": 3,
             "mineralId": 6,
             "quantity": 20
         },
         {
-            "colonyMineralId": 6,
+            "id": 6,
             "colonyId": 3,
             "mineralId": 5,
             "quantity": 20
         },
         {
-            "colonyMineralId": 7,
+            "id": 7,
             "colonyId": 3,
             "mineralId": 4,
             "quantity": 20
         },
         {
-            "colonyMineralId": 8,
+            "id": 8,
             "colonyId": 4,
             "mineralId": 3,
             "quantity": 20
         },
         {
-            "colonyMineralId": 9,
+            "id": 9,
             "colonyId": 5,
             "mineralId": 8,
             "quantity": 20
         },
         {
-            "colonyMineralId": 10,
+            "id": 10,
             "colonyId": 5,
             "mineralId": 7,
             "quantity": 20
         },
         {
-            "colonyMineralId": 11,
+            "id": 11,
             "colonyId": 1,
             "mineralId": 2,
             "quantity": 20
@@ -226,73 +226,73 @@
     ],
     "facilityMinerals": [
         {
-            "facilityMineralId": 1,
+            "id": 1,
             "mineralId": 4,
             "facilityId": 1,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 2,
             "mineralId": 5,
             "facilityId": 1,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 3,
             "mineralId": 1,
             "facilityId": 2,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 4,
             "mineralId": 7,
             "facilityId": 3,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 5,
             "mineralId": 2,
             "facilityId": 3,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 6,
             "mineralId": 6,
             "facilityId": 3,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 7,
             "mineralId": 3,
             "facilityId": 4,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 8,
             "mineralId": 5,
             "facilityId": 4,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 9,
             "mineralId": 1,
             "facilityId": 5,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 10,
             "mineralId": 2,
             "facilityId": 5,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 11,
             "mineralId": 4,
             "facilityId": 6,
             "quantity": 20
         },
         {
-            "facilityMineralId": 1,
+            "id": 12,
             "mineralId": 8,
             "facilityId": 6,
             "quantity": 20

--- a/managers/colonyManager.js
+++ b/managers/colonyManager.js
@@ -1,4 +1,7 @@
 // Colony getter function to fetch colonies from database.json file
-export const getColonies = async () => {
+export const getColonyFromGovernorId = async (governorId) => {
+    const colonyFetch = await fetch(`http://localhost:8088/governors/${governorId}?_expand=colony`)
+    const colonyObj = await colonyFetch.json()
 
+    return colonyObj
 }

--- a/managers/colonyMineralManager.js
+++ b/managers/colonyMineralManager.js
@@ -1,4 +1,7 @@
 // Getter function to fetch colonyMinerals from database.json file
-export const getColonyMinerals = async () => {
+export const getColonyMineralsFromColonyId = async (colonyId) => {
+    const colonyMineralsFetch = await fetch(`http://localhost:8088/colonyMinerals?colonyId=${colonyId}&_expand=mineral`)
+    const colonyMineralsArr = await colonyMineralsFetch.json()
 
+    return colonyMineralsArr
 }

--- a/managers/facilityManager.js
+++ b/managers/facilityManager.js
@@ -1,4 +1,7 @@
 // Getter function to fetch the facilities from the database.json file
 export const getFacilities = async () => {
-    
+    const facilitiesFetch = await fetch("http://localhost:8088/facilities")
+    const facilitiesArray = await facilitiesFetch.json()
+
+    return facilitiesArray
 }

--- a/managers/facilityMineralManager.js
+++ b/managers/facilityMineralManager.js
@@ -1,4 +1,7 @@
 // Getter function to fetch facilityMinerals from database.json file
-export const getFacilityMinerals = async () => {
-    
+export const getFacilityMineralsFromFacilityId = async (facilityId) => {
+    const facilityMineralsFetch = await fetch(`http://localhost:8088/facilities?facilityId=${facilityId}&_expand=mineral`)
+    const facilityMineralsArr = await facilityMineralsFetch.json()
+
+    return facilityMineralsArr
 }

--- a/managers/governorManager.js
+++ b/managers/governorManager.js
@@ -1,4 +1,7 @@
 // Getter function to fetch governors from database.json file
 export const getGovernors = async () => {
-    
+    const governorsFetch = await fetch("http://localhost:8088/governors")
+    const governorsArray = await governorsFetch.json()
+
+    return governorsArray
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,6 +6,8 @@
 // and re-renders the html of the main container when state changes
 
 // imports here
+// import { getGovernors } from "../managers/governorManager.js"
+
 
 // grab the #main-container element and store in variable
 const mainContainer = document.querySelector("#main-container")
@@ -45,3 +47,5 @@ render()
 document.addEventListener("stateChanged", () => {
     render()
 })
+
+// console.log(await getGovernors())


### PR DESCRIPTION
# Description

Defined 5 getter functions in each manager.js file in the `managers` directory
1. `getColonyFromGovernorId()` - takes a governorId as a parameter and returns a single governor object with an expanded colony object with matching colonyId properties
2. `getColonyMineralsFromColonyId()` - takes a colonyId as a parameter and returns an array of colonyMineral objects, each with an expanded mineral object
3. `getFacilities` - no parameters; returns an array of all the facility objects
4. `getFacilityMineralsFromFacilityId` - takes a facilityId as a parameter and returns an array of facilityMineral objects, each with an expanded mineral object
5. `getGovernors` - no parameters; returns an array of all governor objects

Fixes Issue #28


## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Should I Test This?

Test via Postman
1. Test `getColonyFromGovernorId()` fetch via a GET request to `http://localhost:8088/governors/3?_expand=colony`

Should return a 200 OK status with a single governor object with an expanded colony object in the response body:
```json
{
    "id": 3,
    "colonyId": 2,
    "name": "Julia Louis Dreyfus",
    "isActive": true,
    "colony": {
        "id": 2,
        "name": "Proxima"
    }
}
```
2. Test `getColonyMineralsFromColonyId()` fetch via a GET request to `http://localhost:8088/colonyMinerals?colonyId=3&_expand=mineral`

Should return a 200 OK status with an array of colonyMineral objects with a colonyId of 3. Each colonyMineral object should have an expanded mineral object.
Response body:
```json
[
    {
        "id": 5,
        "colonyId": 3,
        "mineralId": 6,
        "quantity": 20,
        "mineral": {
            "id": 6,
            "name": "Nebulium"
        }
    },
    {
        "id": 6,
        "colonyId": 3,
        "mineralId": 5,
        "quantity": 20,
        "mineral": {
            "id": 5,
            "name": "Novacrystal"
        }
    },
    {
        "id": 7,
        "colonyId": 3,
        "mineralId": 4,
        "quantity": 20,
        "mineral": {
            "id": 4,
            "name": "Cosmonite"
        }
    }
]
```
3.  Test `getFacilities()` fetch via a GET request to `http://localhost:8088/facilities`

Should return a 200 OK status with an array of all facility objects in the response body
Response:
```json
[
    {
        "id": 1,
        "name": "Celestial Depot",
        "isActive": true
    },
    {
        "id": 2,
        "name": "Galactic Mart",
        "isActive": false
    }, {...}
]
```
4. Test `getFacilityMineralsFromFacilityId()` via a GET request to `http://localhost:8088/facilityMinerals?facilityId=3&_expand=mineral`

Response: 
200 OK status with an array of facilityMineral objects, each with an expanded mineral object, in the response body
```json
[
    {
        "id": 4,
        "mineralId": 7,
        "facilityId": 3,
        "quantity": 20,
        "mineral": {
            "id": 7,
            "name": "Gravitite"
        }
    },
    {
        "id": 5,
        "mineralId": 2,
        "facilityId": 3,
        "quantity": 20,
        "mineral": {
            "id": 2,
            "name": "Stellarite"
        }
    },
    {
        "id": 6,
        "mineralId": 6,
        "facilityId": 3,
        "quantity": 20,
        "mineral": {
            "id": 6,
            "name": "Nebulium"
        }
    }
]
```

6. Test `getGovernors()` fetch via a GET request to `http://localhost:8088/governors`

Should return a 200 OK status with an array of all governor objects in the response body
Response:
```json
[
    {
        "id": 1,
        "colonyId": 1,
        "name": "Bill Hader",
        "isActive": true
    },
    {
        "id": 2,
        "colonyId": 2,
        "name": "Will Hader",
        "isActive": false
    }, {...}
]
```
# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
