### PR TITLE
Added logic to display dynamic Colony and ColonyMineral info based on…

### DIFF
--- a/managers/colonyManager.js
+++ b/managers/colonyManager.js
@@ -5,3 +5,10 @@ export const getColonyFromGovernorId = async (governorId) => {
 
     return colonyObj
 }
+
+// export const getColony = async (colonyId) => {
+//     const colonyFetch = await fetch(`http://localhost:8088/colonies/${colonyId}`)
+//     const colonyObj = await colonyFetch.json()
+
+//     return colonyObj
+// }

--- a/scripts/ColonyMinerals.js
+++ b/scripts/ColonyMinerals.js
@@ -1,9 +1,28 @@
 // imports
-import { getColonies } from "../managers/colonyManager.js"
-import { getColonyMinerals } from "../managers/colonyMineralManager.js"
+
+import { getColony } from "../managers/colonyManager.js"
+import { getColonyMineralsFromColonyId } from "../managers/colonyMineralManager.js"
+import { state } from "./TransientState.js"
 
 // Component function to render html for the colony minerals for the colony of the selected governor
 // Will be rendered in the #chosen-governor-colony-minerals container in the mainContainer html
 export const ColonyMinerals = async () => {
+    let html = "<h2>Colony Minerals</h2>"
 
+    if (state.selectedGovernorColonyId) {
+        const colonyObj = await getColony(state.selectedGovernorColonyId)
+        const colonyMineralsArr = await getColonyMineralsFromColonyId(state.selectedGovernorColonyId)
+
+        html = `<h2>${colonyObj.name}</h2>`
+
+        html += colonyMineralsArr.map(colonyMineral => {
+            return `
+                <ul>
+                    <li>${colonyMineral.quantity} tons of ${colonyMineral.mineral.name}</li>
+                </ul>
+            `
+        }).join("")
+    }
+
+    return html
 }

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,6 +1,6 @@
 // imports
 import { getGovernors } from "../managers/governorManager.js";
-import { setGovernor } from "./TransientState.js";
+import { setColony, setGovernor } from "./TransientState.js";
 
 // Component function to render the html for a select dropdown with options for the active governors
 // inside the #governor-select-container in the main.js render() function
@@ -17,7 +17,7 @@ export const Governors = async () => {
     html += governors.map(governor => {
         if (governor.isActive) {
             return `
-                <option value="${governor.id}">${governor.name}</option>
+                <option value="${governor.id}" data-colony-id="${governor.colonyId}">${governor.name}</option>
             `
         }
     }).join("")
@@ -29,9 +29,12 @@ export const Governors = async () => {
 
 const handleGovernorChange = (event) => {
     if (event.target.name === "governor") {
+        const selectedOption = event.target.options[event.target.selectedIndex]
         const selectedGovernorId = parseInt(event.target.value)
+        const selectedGovernorColonyId = parseInt(selectedOption.dataset.colonyId)
         // console.log(selectedGovernorId)
         setGovernor(selectedGovernorId)
+        setColony(selectedGovernorColonyId)
     }
 }
 

--- a/scripts/TransientState.js
+++ b/scripts/TransientState.js
@@ -1,10 +1,16 @@
-const state = {
+export const state = {
     selectedGovernorId: 0,
+    selectedGovernorColonyId: 0,
     selectedFacilityId: 0
 }
 
 export const setGovernor = (governorId) => {
     state.selectedGovernorId = governorId
+    document.dispatchEvent(new CustomEvent("stateChanged"))
+}
+
+export const setColony = (colonyId) => {
+    state.selectedGovernorColonyId = colonyId
     console.log(state)
     document.dispatchEvent(new CustomEvent("stateChanged"))
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,6 +5,7 @@
 // and set up click event to call a custom click event that calls the render() function
 // and re-renders the html of the main container when state changes
 
+import { ColonyMinerals } from "./ColonyMinerals.js"
 import { Governors } from "./Governors.js"
 
 // imports here
@@ -26,7 +27,7 @@ const render = async () => {
                 ${await Governors()}
             </section>
             <section id="selected-governor-colony-minerals-container">
-            
+                ${await ColonyMinerals()}
             </section>
             <section id="facility-select-container">
             


### PR DESCRIPTION
… the Governor selected from the governor-select dropdown

# Description

- Added a `setColony()` setter function in TransientState.js that sets the `state.selectedGovernorColonyId` with the colonyId that is passed in
- Called the `setColony()` setter function inside the `handleGovernorChange()` function in Governors.js, which utilizes the `data-colony-id` attribute of the selected governor target
- Set the initial html of the ColonyMinerals to be an `<h2>` element that says "Colony Minerals" before a governor is selected.
- Once a governor is selected and the `handleGovernorChange()` function is called, which sets the `selectedGovernorColonyId` property of the state variable, the html is updated, and the state of the webpage is re-rendered

Fixes Issue Ticket #30 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Should I Test This?

- [x] Run the `serve` command in the terminal in the main project directory
- [x] Run `json-server database.json -p 8088 --watch` inside the `api` directory in the terminal
- [x] Go to `http://localhost:3000`
- [x] Make sure "Colony Minerals" renders before a governor is selected
- [x] Make sure after a governor is selected, the name of their Colony and the amount and name of each Colony Mineral for that colony renders, replacing the "Colony Minerals" header

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
