### PR TITLE
Added selected attribute to governor option that is selected

### DIFF
--- a/managers/colonyManager.js
+++ b/managers/colonyManager.js
@@ -1,14 +1,14 @@
 // Colony getter function to fetch colonies from database.json file
-export const getColonyFromGovernorId = async (governorId) => {
-    const colonyFetch = await fetch(`http://localhost:8088/governors/${governorId}?_expand=colony`)
-    const colonyObj = await colonyFetch.json()
-
-    return colonyObj
-}
-
-// export const getColony = async (colonyId) => {
-//     const colonyFetch = await fetch(`http://localhost:8088/colonies/${colonyId}`)
+// export const getColonyFromGovernorId = async (governorId) => {
+//     const colonyFetch = await fetch(`http://localhost:8088/governors/${governorId}?_expand=colony`)
 //     const colonyObj = await colonyFetch.json()
 
 //     return colonyObj
 // }
+
+export const getColony = async (colonyId) => {
+    const colonyFetch = await fetch(`http://localhost:8088/colonies/${colonyId}`)
+    const colonyObj = await colonyFetch.json()
+
+    return colonyObj
+}

--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -1,6 +1,6 @@
 // imports
 import { getGovernors } from "../managers/governorManager.js";
-import { setColony, setGovernor } from "./TransientState.js";
+import { setColony, setGovernor, state } from "./TransientState.js";
 
 // Component function to render the html for a select dropdown with options for the active governors
 // inside the #governor-select-container in the main.js render() function
@@ -16,8 +16,10 @@ export const Governors = async () => {
 
     html += governors.map(governor => {
         if (governor.isActive) {
+            const isSelected = governor.id === state.selectedGovernorId
+
             return `
-                <option value="${governor.id}" data-colony-id="${governor.colonyId}">${governor.name}</option>
+                <option value="${governor.id}" data-colony-id="${governor.colonyId}" ${isSelected ? 'selected' : ''}>${governor.name}</option>
             `
         }
     }).join("")


### PR DESCRIPTION
# Description
- Before, when an active Governor was selected from the governor-select dropdown, the selected governor would disappear when the html re-rendered to display that Governor's Colony and Colony Minerals.
- Added an `isSelected` variable inside the `Governors()` component function that checks the `id` property of the current governor being mapped through against the `state.selectedGovernorId` property and sets the `selected` attribute of the html `<option>` for the governor that returns `true`.
- Now, when a governor is selected from the governor-select dropdown, the `state.selectedGovernorId` is set, the main html re-renders, so the `Governors()` component function is called again and the `selected` property is set to the selected Governor and persists.

Fixes Issue Ticket #33

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Should I Test This?

Please describe the steps required to verify your changes. Provide instructions so your teammate can reproduce.

- [x] Run `serve` command in the terminal inside the main project directory
- [x] Run `json-server database.json -p 8088 --watch` to enable fetch calls to the database.json() file
- [x] Select a Governor from the governor-select dropdown
- [x] Make sure that the Governor remains selected in the dropdown and that Governor's Colony plus that Colony's Minerals display on the page.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no errors
